### PR TITLE
Fix - Update to new installation URL

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: Horusec Scan
 
-on: [push, workflow_dispatch]
+on: [push]
 
 jobs:
   checking_code:
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Run Horusec
         id: run_horusec
-        uses: GuillaumeFalourd/horusec-action@main
+        uses: fike/horusec-action@main
         with:
           arguments: -p="./" --ignore="**/.vscode/**, **/*.env, **/.mypy_cache/**, **/tests/**"
         

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Run Horusec
         id: run_horusec
-        uses: ./
+        uses: GuillaumeFalourd/horusec-action@main
         with:
           arguments: -p="./" --ignore="**/.vscode/**, **/*.env, **/.mypy_cache/**, **/tests/**"
         

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: Horusec Scan
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   checking_code:
@@ -8,10 +8,10 @@ jobs:
     name: Horusec Scan
     steps:
       - name: Checkout 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Run Horusec
         id: run_horusec
-        uses: fike/horusec-action@v0.1-alpha
+        uses: ./
         with:
           arguments: -p="./" --ignore="**/.vscode/**, **/*.env, **/.mypy_cache/**, **/tests/**"
         

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN apk add curl bash sudo && \
     curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest 
-#     && \
-#     mv horusec /usr/local/bin/horusec && \
-#     chmod 0775 /usr/local/bin/horusec /entrypoint.sh
 
 WORKDIR /opt/data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:latest
 COPY entrypoint.sh /entrypoint.sh
 
 RUN apk add curl  && \
-    curl -fsSL  https://horusec.io/bin/latest/linux_x64/horusec -o horusec && \
+    curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest && \
     mv horusec /usr/local/bin/horusec && \
     chmod 0775 /usr/local/bin/horusec /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:latest
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add curl bash && \
+RUN apk add curl bash sudo && \
     curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest && \
     mv horusec /usr/local/bin/horusec && \
     chmod 0775 /usr/local/bin/horusec /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:latest
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add curl  && \
+RUN apk add curl bash && \
     curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest && \
     mv horusec /usr/local/bin/horusec && \
     chmod 0775 /usr/local/bin/horusec /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@ FROM alpine:latest
 COPY entrypoint.sh /entrypoint.sh
 
 RUN apk add curl bash sudo && \
-    curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest && \
-    mv horusec /usr/local/bin/horusec && \
-    chmod 0775 /usr/local/bin/horusec /entrypoint.sh
+    curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest 
+#     && \
+#     mv horusec /usr/local/bin/horusec && \
+#     chmod 0775 /usr/local/bin/horusec /entrypoint.sh
 
 WORKDIR /opt/data
 


### PR DESCRIPTION
The url being used for installation has been deprecated as it only had a few first versions of Horusec. 

It is no longer updated.

It's currently recommend to install Horusec by downloading directly from Github:

https://docs.horusec.io/docs/pt-br/cli/installation/
https://github.com/ZupIT/horusec#installing-horusec

Therefore, the command that should be used is the following one:

```curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest```

The new workflow has been tested on [this fork workflow run](https://github.com/GuillaumeFalourd/horusec-action/runs/4354050520?check_suite_focus=true)

### Suggestion:

It could be interesting to add a `schedule` trigger on the action workflow to check from time to time if the action is still working as expected.